### PR TITLE
Initialize Flux Mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: alerts
+alerts:
+	mkdir -p files
+	rm -rf files/alerts.yml
+	jsonnet -J vendor -S -e 'std.manifestYamlDoc((import "mixin.libsonnet").prometheusAlerts)' > files/alerts.yml
+
+.PHONY: dashboards
+dashboards:
+	rm -rf files/dashboards
+	mkdir -p files/dashboards
+	jsonnet -J vendor -m files/dashboards -e '(import "mixin.libsonnet").grafanaDashboards'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Flux-mixin can support dashboards across multiple clusters. You need either a mu
     clusterLabel: '<your cluster label>',
 ```
 
+## Generate flux alerts and dashboards
+
+Alerts and dashboards will be generated to `files/` directory using:
+
+```shell
+make alerts
+make dashboards
+```
+
 ## Use as a library
 
 To use the `flux-mixin` as a dependency, simply use the `jsonnet-bundler` to install:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,69 @@
-# Prometheus Monitoring Mixin for Flux
+# Prometheus Monitoring Mixin for Flux V2
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
+## Requirements
 
+### jsonnet
+
+`Flux-mixin` use `jsonnet`
+
+We recommend to use [go-jsonnet](https://github.com/google/go-jsonnet). It's an implementation of [Jsonnet](http://jsonnet.org/) in pure Go. It is feature complete but is not as heavily exercised as the [Jsonnet C++ implementation](https://github.com/google/jsonnet).
+
+To install:
+
+```shell
+go get github.com/google/go-jsonnet/cmd/jsonnet
+```
+
+### jsonnet-bundler
+
+`Flux-mixin` uses [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler#install) (the jsonnet package manager) to manage its dependencies.
+
+We recommended you to use `jsonnet-bundler` to install or update if you decide to use `flux-mixin` as a dependency for your custom mixins.
+
+```
+go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+```
+
+## Multi-cluster support
+
+Flux-mixin can support dashboards across multiple clusters. You need either a multi-cluster [Thanos](https://github.com/improbable-eng/thanos) installation with `external_labels` configured or a [Cortex](https://github.com/cortexproject/cortex) system where a cluster label exists. To enable this feature you need to configure the following:
+
+```
+    // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
+    showMultiCluster: true,
+    clusterLabel: '<your cluster label>',
+```
+
+## Use as a library
+
+To use the `flux-mixin` as a dependency, simply use the `jsonnet-bundler` to install:
+
+```shell
+$ mkdir custom-mixin; cd custom-mixin
+$ jb init # Create/Initial empty `jsonnetfile.json` for dependency management
+# Install flux-mixin dependency
+$ jb install github.com/fluxcd-community/flux-mixin
+```
+
+in a directory, add a file `mixin.libsonnet`:
+
+```libsonnet
+local flux = import "github.com/fluxcd-community/flux-mixin/mixin.libsonnet"; // import full path to avoid collusion with other mixin
+
+flux {
+  _config+:: {
+    showMultiCluster: true,
+    clusterLabel: 'cluster',
+  },
+}
+```
+
+Then generate the alerts and dashboards
+
+```shell
+$ mkdir -p files/dashboards 
+$ jsonnet -J vendor -S -e 'std.manifestYamlDoc((import "mixin.libsonnet").prometheusAlerts)' > flies/alerts.yml
+$ jsonnet -J vendor -m files/dashboards -e '(import "mixin.libsonnet").grafanaDashboards'
+```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Flux-mixin can support dashboards across multiple clusters. You need either a mu
 Alerts and dashboards will be generated to `files/` directory using:
 
 ```shell
+jb install
+
 make alerts
 make dashboards
 ```

--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -1,0 +1,1 @@
+(import 'flux-alert.libsonnet')

--- a/alerts/flux-alert.libsonnet
+++ b/alerts/flux-alert.libsonnet
@@ -1,0 +1,26 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'flux-alert',
+        rules: [
+          {
+            alert: 'FluxReconcilationFailed',
+            expr: |||
+              max(gotk_reconcile_condition{status="False",type="Ready"}) by (namespace, name, kind) + on(namespace, name, kind) (max(gotk_reconcile_condition{status="Deleted"}) by (namespace, name, kind)) * 2 == 1
+            |||,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: '{{ $labels.kind }} {{ $labels.name }} reconcilation has been failed for more than 10 minutes in {{ $labels.exported_namespace }} namespace',
+              runbook_url: '',
+              summary: 'Flux {{ $labels.kind }} {{ $labels.name }} failed',
+            },
+            'for': '10m',
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -1,0 +1,6 @@
+{
+  _config+:: {
+    showMultiCluster: true,
+    clusterLabel: 'cluster',
+  },
+}

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _config+:: {
-    showMultiCluster: true,
+    showMultiCluster: false,
     clusterLabel: 'cluster',
   },
 }

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -1,0 +1,2 @@
+(import 'flux-cluster.libsonnet') +
+(import 'flux-control-plane.libsonnet')

--- a/dashboards/flux-cluster.libsonnet
+++ b/dashboards/flux-cluster.libsonnet
@@ -1,0 +1,381 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+
+local barGaugePanel = grafana.barGaugePanel;
+local dashboard = grafana.dashboard;
+local graphPanel = grafana.graphPanel;
+local prometheus = grafana.prometheus;
+local row = grafana.row;
+local statPanel = grafana.statPanel;
+local tablePanel = grafana.tablePanel;
+local template = grafana.template;
+
+{
+  grafanaDashboards+:: {
+    'flux-cluster.json':
+      local clusterReconcilers =
+        statPanel.new(
+          title='Cluster Reconcilers',
+          datasource='$datasource',
+          graphMode='none',
+          reducerFunction='last',
+        )
+        .addTarget(
+          prometheus.target(
+            |||
+              count(gotk_reconcile_condition{%(clusterLabel)s="$cluster",namespace=~"$namespace",type="Ready",status="True",kind=~"Kustomization|HelmRelease"})
+              -
+              sum(gotk_reconcile_condition{%(clusterLabel)s="$cluster",namespace=~"$namespace",type="Ready",status="Deleted",kind=~"Kustomization|HelmRelease"})
+            ||| % $._config,
+          )
+        )
+        .addThreshold({ color: 'blue', value: null })
+        .addThreshold({ color: 'red', value: 100 });
+
+      local failingReconcilers =
+        statPanel.new(
+          title='Failing Reconcilers',
+          datasource='$datasource',
+          reducerFunction='last',
+        )
+        .addTarget(
+          prometheus.target('sum(gotk_reconcile_condition{%(clusterLabel)s="$cluster",namespace=~"$namespace",type="Ready",status="False",kind=~"Kustomization|HelmRelease"})' % $._config)
+        )
+        .addThreshold({ color: 'red', value: null });
+
+      local kubernetesManifestSources =
+        statPanel.new(
+          title='Kubernetes Manifests Sources',
+          datasource='$datasource',
+          graphMode='none',
+          reducerFunction='last',
+        )
+        .addTarget(
+          prometheus.target(
+            |||
+              count(gotk_reconcile_condition{%(clusterLabel)s="$cluster",namespace=~"$namespace",type="Ready",status="True",kind=~"GitRepository|HelmRepository|Bucket"})
+              -
+              sum(gotk_reconcile_condition{%(clusterLabel)s="$cluster",namespace=~"$namespace",type="Ready",status="Deleted",kind=~"GitRepository|HelmRepository|Bucket"})
+            ||| % $._config,
+          )
+        )
+        .addThreshold({ color: 'blue', value: null })
+        .addThreshold({ color: 'red', value: 100 });
+
+
+      local failingSources =
+        statPanel.new(
+          title='Failing Sources',
+          datasource='$datasource',
+          reducerFunction='last',
+        )
+        .addTarget(
+          prometheus.target(
+            'sum(gotk_reconcile_condition{%(clusterLabel)s="$cluster",namespace=~"$namespace",type="Ready",status="False",kind=~"GitRepository|HelmRepository|Bucket"})' % $._config,
+          )
+        )
+        .addThreshold({ color: 'red', value: 0 });
+
+      local reconcilerOpsAvgSec =
+        barGaugePanel.new(
+          title='Reconciler ops avg. duration',
+          datasource='$datasource',
+          unit='s',
+          thresholds=[
+            { color: 'green', value: null },
+            { color: 'yellow', value: 1 },
+            { color: 'red', value: 61 },
+          ]
+        )
+        .addTarget(
+          prometheus.target(
+            |||
+              sum(rate(gotk_reconcile_duration_seconds_sum{%(clusterLabel)s="$cluster",namespace=~"$namespace",kind=~"Kustomization|HelmRelease"}[5m])) by (kind)
+              /
+              sum(rate(gotk_reconcile_duration_seconds_count{%(clusterLabel)s="$cluster",namespace=~"$namespace",kind=~"Kustomization|HelmRelease"}[5m])) by (kind)
+            ||| % $._config,
+            legendFormat='{{kind}}'
+          )
+        ) + {
+          options: {
+            orientation: 'horizontal',
+            reduceOptions: {
+              calcs: ['mean'],
+              fields: '',
+              values: false,
+            },
+          },
+        };
+
+      local sourceOpsAvgSec =
+        barGaugePanel.new(
+          title='Source ops avg. duration',
+          datasource='$datasource',
+          unit='s',
+          thresholds=[
+            { color: 'green', value: null },
+            { color: 'yellow', value: 1 },
+            { color: 'red', value: 61 },
+          ]
+        )
+        .addTarget(
+          prometheus.target(
+            |||
+              sum(rate(gotk_reconcile_duration_seconds_sum{%(clusterLabel)s="$cluster",namespace=~"$namespace",kind=~"GitRepository|HelmRepository|Bucket"}[5m])) by (kind)
+              /
+              sum(rate(gotk_reconcile_duration_seconds_count{%(clusterLabel)s="$cluster",namespace=~"$namespace",kind=~"GitRepository|HelmRepository|Bucket"}[5m])) by (kind)
+            ||| % $._config,
+            legendFormat='{{kind}}'
+          )
+        ) + {
+          options: {
+            orientation: 'horizontal',
+            reduceOptions: {
+              calcs: ['mean'],
+              fields: '',
+              values: false,
+            },
+          },
+        };
+
+      local statusPanelOverride = {
+        // Ref: https://github.com/grafana/grafonnet-lib/issues/240
+        styles: null,  // potential fix for grafonnet use type `table-old` format
+        fieldConfig: {
+          defaults: {
+            mappings: [
+              {
+                from: '',
+                id: 1,
+                text: 'Ready',
+                to: '',
+                type: 1,
+                value: '0',
+              },
+              {
+                from: '',
+                id: 2,
+                text: 'Not Ready',
+                to: '',
+                type: 1,
+                value: '1',
+              },
+            ],
+            thresholds: {
+              mode: 'absolute',
+              steps: [
+                {
+                  color: 'blue',
+                  value: null,
+                },
+                {
+                  color: 'blue',
+                  value: 0,
+                },
+                {
+                  color: 'red',
+                  value: 1,
+                },
+              ],
+            },
+          },
+          overrides: [
+            {
+              matcher: {
+                id: 'byName',
+                options: 'Status',
+              },
+              properties: [
+                {
+                  id: 'custom.displayMode',
+                  value: 'color-background',
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      local statusPanelTransformationObj =
+        [
+          {
+            id: 'organize',
+            options: {
+              excludeByName: {
+                Time: true,
+                __name__: true,
+                app: true,
+                cluster: true,
+                container: true,
+                endpoint: true,
+                environment: true,
+                exported_namespace: true,
+                instance: true,
+                job: true,
+                kubernetes_namespace: true,
+                kubernetes_pod_name: true,
+                pod: true,
+                pod_template_hash: true,
+                project: true,
+                prometheus: true,
+                prometheus_replica: true,
+                receive: true,
+                status: true,
+                tenant_id: true,
+                type: true,
+              },
+              indexByName: {},
+              renameByName: {
+                Value: 'Status',
+                kind: 'Kind',
+                name: 'Name',
+                namespace: 'Namespace',
+              },
+            },
+          },
+        ];
+
+      local clusterReconciliationReadiness =
+        tablePanel.new(
+          title='Cluster reconciliation readiness',
+          datasource='$datasource',
+        )
+        .addTarget(
+          prometheus.target(
+            'gotk_reconcile_condition{%(clusterLabel)s="$cluster",namespace=~"$namespace",type="Ready",status="False",kind=~"Kustomization|HelmRelease"}' % $._config,
+            format='table',
+            instant=true
+          )
+        )
+        .addTransformations(
+          statusPanelTransformationObj
+        ) + statusPanelOverride;
+
+      local sourceAcquisitionReadiness =
+        tablePanel.new(
+          title='Source acquisition readiness',
+          datasource='$datasource',
+        )
+        .addTarget(
+          prometheus.target(
+            'gotk_reconcile_condition{%(clusterLabel)s="$cluster",namespace=~"$namespace",type="Ready",status="False",kind=~"GitRepository|HelmRepository|Bucket"}' % $._config,
+            format='table',
+            instant=true
+          )
+        )
+        .addTransformations(
+          statusPanelTransformationObj
+        ) + statusPanelOverride;
+
+      local clusterReconciliationDuration =
+        graphPanel.new(
+          title='Cluster reconciliation duration',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_rightSide=true,
+          legend_hideEmpty=true,
+          legend_hideZero=true,
+          legend_values=true,
+          format='s'
+        )
+        .addTarget(
+          prometheus.target(
+            |||
+              sum(rate(gotk_reconcile_duration_seconds_sum{%(clusterLabel)s="$cluster",namespace=~"$namespace",kind=~"Kustomization|HelmRelease"}[5m])) by (kind, name)
+              /
+              sum(rate(gotk_reconcile_duration_seconds_count{%(clusterLabel)s="$cluster",namespace=~"$namespace",kind=~"Kustomization|HelmRelease"}[5m])) by (kind, name)
+            ||| % $._config,
+            legendFormat='{{kind}}/{{name}}'
+          )
+        );
+
+      local sourceAcquisitionDuration =
+        graphPanel.new(
+          title='Source acquisition duration',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_rightSide=true,
+          legend_hideEmpty=true,
+          legend_hideZero=true,
+          legend_values=true,
+          format='s'
+        )
+        .addTarget(
+          prometheus.target(
+            |||
+              sum(rate(gotk_reconcile_duration_seconds_sum{%(clusterLabel)s="$cluster",namespace=~"$namespace",kind=~"GitRepository|HelmRepository|Bucket"}[5m])) by (kind, name)
+              /
+              sum(rate(gotk_reconcile_duration_seconds_count{%(clusterLabel)s="$cluster",namespace=~"$namespace",kind=~"GitRepository|HelmRepository|Bucket"}[5m])) by (kind, name)
+            ||| % $._config,
+            legendFormat='{{kind}}/{{name}}'
+          )
+        );
+
+      dashboard.new(
+        'Flux / Cluster Stats',
+        time_from='now-15m',
+        uid='flux-cluster',
+        tags=['flux'],
+      )
+      .addTemplate(
+        {
+          current: {
+            text: 'prometheus',
+            value: 'prometheus',
+          },
+          hide: 0,
+          label: null,
+          name: 'datasource',
+          options: [],
+          query: 'prometheus',
+          refresh: 1,
+          regex: '',
+          type: 'datasource',
+        },
+      )
+      .addTemplate(
+        template.new(
+          'cluster',
+          '$datasource',
+          'label_values(gotk_reconcile_condition, %(clusterLabel)s)' % $._config,
+          label='cluster',
+          refresh='time',
+          hide=if $._config.showMultiCluster then '' else 'variable',
+          sort=1,
+        )
+      )
+      .addTemplate(
+        template.new(
+          'namespace',
+          '$datasource',
+          'label_values(gotk_reconcile_condition{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
+          refresh='time',
+          includeAll=true,
+          sort=1,
+        )
+      )
+      .addPanel(clusterReconcilers, gridPos={ h: 5, w: 6, x: 0, y: 0 })
+      .addPanel(failingReconcilers, gridPos={ h: 5, w: 6, x: 6, y: 0 })
+      .addPanel(kubernetesManifestSources, gridPos={ h: 5, w: 6, x: 12, y: 0 })
+      .addPanel(failingSources, gridPos={ h: 5, w: 6, x: 18, y: 0 })
+      .addPanel(reconcilerOpsAvgSec, gridPos={ h: 4, w: 12, x: 0, y: 5 })
+      .addPanel(sourceOpsAvgSec, gridPos={ h: 4, w: 12, x: 12, y: 5 })
+      .addPanel(
+        row.new(
+          title='Status'
+        ),
+        gridPos={ h: 1, w: 24, x: 0, y: 9 }
+      )
+      .addPanel(clusterReconciliationReadiness, gridPos={ h: 8, w: 12, x: 0, y: 10 })
+      .addPanel(sourceAcquisitionReadiness, gridPos={ h: 8, w: 12, x: 12, y: 10 })
+      .addPanel(
+        row.new(
+          title='Timing'
+        ),
+        gridPos={ h: 1, w: 24, x: 0, y: 18 }
+      )
+      .addPanel(clusterReconciliationDuration, gridPos={ h: 8, w: 24, x: 0, y: 19 })
+      .addPanel(sourceAcquisitionDuration, gridPos={ h: 8, w: 24, x: 0, y: 27 }),
+  },
+}

--- a/dashboards/flux-control-plane.libsonnet
+++ b/dashboards/flux-control-plane.libsonnet
@@ -1,0 +1,411 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+
+local dashboard = grafana.dashboard;
+local gaugePanel = grafana.gaugePanel;
+local graphPanel = grafana.graphPanel;
+local prometheus = grafana.prometheus;
+local row = grafana.row;
+local statPanel = grafana.statPanel;
+local template = grafana.template;
+
+{
+  grafanaDashboards+:: {
+    'flux-control-plane.json':
+      local controllers =
+        statPanel.new(
+          title='Controllers',
+          datasource='$datasource',
+          graphMode='none',
+          reducerFunction='last',
+        )
+        .addTarget(
+          prometheus.target(
+            'sum(go_info{%(clusterLabel)s="$cluster",namespace="$namespace",pod=~".*-controller-.*"})' % $._config,
+          )
+        )
+        .addThreshold({ color: 'blue', value: null })
+        .addThreshold({ color: 'red', value: 100 });
+
+      local maxWorkQueue =
+        statPanel.new(
+          title='Max Work Queue',
+          datasource='$datasource',
+          reducerFunction='lastNotNull',
+          unit='s'
+        )
+        .addTarget(
+          prometheus.target(
+            'max(workqueue_longest_running_processor_seconds{%(clusterLabel)s="$cluster",namespace="$namespace",pod=~".*-controller-.*"})' % $._config,
+            legendFormat='seconds',
+            intervalFactor=1,
+          )
+        )
+        .addThreshold({ color: 'blue', value: null })
+        .addThreshold({ color: 'yellow', value: 50 })
+        .addThreshold({ color: 'red', value: 100 });
+
+      local memory =
+        gaugePanel.new(
+          title='Memory',
+          datasource='$datasource',
+          reducerFunction='lastNotNull',
+          unit='decbits',
+          min=null,
+          max=null,
+        )
+        .addTarget(
+          prometheus.target(
+            'sum(go_memstats_alloc_bytes{%(clusterLabel)s="$cluster",namespace="$namespace",pod=~".*-controller-.*"})' % $._config,
+          )
+        )
+        .addThreshold({ color: 'blue', value: null })
+        .addThreshold({ color: 'yellow', value: 500000000 })  // 500Mb
+        .addThreshold({ color: 'red', value: 900000000 });  // 900Mb
+
+      local apiRequests =
+        statPanel.new(
+          title='API Requests',
+          datasource='$datasource',
+        )
+        .addTarget(
+          prometheus.target(
+            'sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",namespace="$namespace",pod=~".*-controller-.*"}[1m]))' % $._config,
+            legendFormat='requests'
+          )
+        )
+        .addThreshold({ color: 'blue', value: null })
+        .addThreshold({ color: 'yellow', value: 50 })
+        .addThreshold({ color: 'red', value: 100 });
+
+      local kubernetesAPIRequestsDuration =
+        graphPanel.new(
+          title='Kubernetes API Requests Duration',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_hideEmpty=true,
+          legend_hideZero=true,
+          legend_values=true,
+          format='s'
+        )
+        .addTargets(
+          [
+            prometheus.target(
+              'histogram_quantile(0.50, sum(rate(rest_client_request_latency_seconds_bucket{%(clusterLabel)s="$cluster",namespace="$namespace"}[5m])) by (le))' % $._config,
+              legendFormat='P50',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'histogram_quantile(0.90, sum(rate(rest_client_request_latency_seconds_bucket{%(clusterLabel)s="$cluster",namespace="$namespace"}[5m])) by (le))' % $._config,
+              legendFormat='P90',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'histogram_quantile(0.99, sum(rate(rest_client_request_latency_seconds_bucket{%(clusterLabel)s="$cluster",namespace="$namespace"}[5m])) by (le))' % $._config,
+              legendFormat='P99',
+              intervalFactor=1
+            ),
+          ]
+        );
+
+      local kubernetesAPIRequests =
+        graphPanel.new(
+          title='Kubernetes API Requests',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+        )
+        .addTargets(
+          [
+            prometheus.target(
+              'sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[1m]))' % $._config,
+              legendFormat='total',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",namespace="$namespace",code!~"2.."}[1m]))' % $._config,
+              legendFormat='error',
+              intervalFactor=1
+            ),
+          ]
+        );
+
+      local cpuUsage =
+        graphPanel.new(
+          title='CPU Usage',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+          stack=true,
+          format='s'
+        )
+        .addTarget(
+          prometheus.target(
+            'rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster",namespace="$namespace",pod=~".*-controller-.*"}[1m])' % $._config,
+            legendFormat='{{pod}}',
+            intervalFactor=1
+          ),
+        );
+
+      local memoryUsage =
+        graphPanel.new(
+          title='Memory Usage',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+          stack=true,
+          format='bytes'
+        )
+        .addTarget(
+          prometheus.target(
+            'rate(go_memstats_alloc_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace",pod=~".*-controller-.*"}[1m])' % $._config,
+            legendFormat='{{pod}}',
+            intervalFactor=1
+          ),
+        );
+
+      local clusterReconciliationDuration =
+        graphPanel.new(
+          title='Cluster Reconciliation Duration',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+          format='s'
+        )
+        .addTarget(
+          prometheus.target(
+            'workqueue_longest_running_processor_seconds{%(clusterLabel)s="$cluster",name="kustomization"}' % $._config,
+            legendFormat='kustomization',
+            intervalFactor=1
+          ),
+        );
+
+      local clusterReconciliationOpsMin =
+        graphPanel.new(
+          title='Cluster Reconciliations ops/min',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+          bars=true,
+          lines=false,
+          decimals=2,
+          format='opm'
+        )
+        .addTargets(
+          [
+            prometheus.target(
+              'sum(increase(controller_runtime_reconcile_total{%(clusterLabel)s="$cluster",controller="kustomization",result!="error"}[1m])) by (controller)' % $._config,
+              legendFormat='successful reconciliations',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'sum(increase(controller_runtime_reconcile_total{%(clusterLabel)s="$cluster",controller="kustomization",result="error"}[1m])) by (controller)' % $._config,
+              legendFormat='failed reconciliations',
+              intervalFactor=1
+            ),
+          ]
+        );
+
+      local gitSourcesOpsMin =
+        graphPanel.new(
+          title='Git Sources ops/min',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+          bars=true,
+          lines=false,
+          decimals=2,
+          format='opm'
+        )
+        .addTargets(
+          [
+            prometheus.target(
+              'sum(increase(controller_runtime_reconcile_total{%(clusterLabel)s="$cluster",controller="gitrepository",result!="error"}[1m]))' % $._config,
+              legendFormat='successful git pulls',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'sum(increase(controller_runtime_reconcile_total{%(clusterLabel)s="$cluster",controller="gitrepository",result="error"}[1m]))' % $._config,
+              legendFormat='failed git pulls',
+              intervalFactor=1
+            ),
+          ]
+        );
+
+      local helmReleaseDuration =
+        graphPanel.new(
+          title='Helm',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+          format='s'
+        )
+        .addTargets(
+          [
+            prometheus.target(
+              'histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{%(clusterLabel)s="$cluster",controller="helmrelease"}[5m])) by (le))' % $._config,
+              legendFormat='P50',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'histogram_quantile(0.90, sum(rate(controller_runtime_reconcile_time_seconds_bucket{%(clusterLabel)s="$cluster",controller="helmrelease"}[5m])) by (le))' % $._config,
+              legendFormat='P90',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{%(clusterLabel)s="$cluster",controller="helmrelease"}[5m])) by (le))' % $._config,
+              legendFormat='P99',
+              intervalFactor=1
+            ),
+          ]
+        );
+
+      local helmReleasesOpsMin =
+        graphPanel.new(
+          title='Helm Releases ops/min',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+          bars=true,
+          lines=false,
+          decimals=2,
+          format='opm'
+        )
+        .addTargets(
+          [
+            prometheus.target(
+              'sum(increase(controller_runtime_reconcile_total{%(clusterLabel)s="$cluster",controller="helmrelease",result!="error"}[1m])) by (controller)' % $._config,
+              legendFormat='successful reconciliations',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'sum(increase(controller_runtime_reconcile_total{%(clusterLabel)s="$cluster",controller="helmrelease",result="error"}[1m])) by (controller)' % $._config,
+              legendFormat='failed reconciliations ',
+              intervalFactor=1
+            ),
+          ]
+        );
+
+      local helmChartsOpsMin =
+        graphPanel.new(
+          title='Helm Charts ops/min',
+          datasource='$datasource',
+          legend_alignAsTable=true,
+          legend_avg=true,
+          legend_current=true,
+          legend_values=true,
+          bars=true,
+          lines=false,
+          decimals=2,
+          format='opm'
+        )
+        .addTargets(
+          [
+            prometheus.target(
+              'sum(increase(controller_runtime_reconcile_total{%(clusterLabel)s="$cluster",controller="helmchart",result!="error"}[1m])) by (controller)' % $._config,
+              legendFormat='successful chart pulls',
+              intervalFactor=1
+            ),
+            prometheus.target(
+              'sum(increase(controller_runtime_reconcile_total{%(clusterLabel)s="$cluster",controller="helmchart",result="error"}[1m])) by (controller)' % $._config,
+              legendFormat='failed chart pulls',
+              intervalFactor=1
+            ),
+          ]
+        );
+
+
+      // FIXME: change to correct uid
+      dashboard.new(
+        'Flux / Control Plane',
+        time_from='now-15m',
+        uid='flux-control-plane-test',
+        tags=['flux'],
+      )
+      .addTemplate(
+        {
+          current: {
+            text: 'prometheus',
+            value: 'prometheus',
+          },
+          hide: 0,
+          label: null,
+          name: 'datasource',
+          options: [],
+          query: 'prometheus',
+          refresh: 1,
+          regex: '',
+          type: 'datasource',
+        },
+      )
+      .addTemplate(
+        template.new(
+          'cluster',
+          '$datasource',
+          'label_values(gotk_reconcile_condition, %(clusterLabel)s)' % $._config,
+          label='cluster',
+          refresh='time',
+          hide=if $._config.showMultiCluster then '' else 'variable',
+          sort=1,
+        )
+      )
+      .addTemplate(
+        template.new(
+          'namespace',
+          '$datasource',
+          'label_values(gotk_reconcile_condition{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
+          refresh='time',
+          sort=1,
+        )
+      )
+      .addPanel(controllers, gridPos={ h: 5, w: 6, x: 0, y: 0 })
+      .addPanel(maxWorkQueue, gridPos={ h: 5, w: 6, x: 6, y: 0 })
+      .addPanel(memory, gridPos={ h: 5, w: 6, x: 12, y: 0 })
+      .addPanel(apiRequests, gridPos={ h: 5, w: 6, x: 18, y: 0 })
+      .addPanel(
+        row.new(
+          title='Resource Usage'
+        ),
+        gridPos={ h: 1, w: 24, x: 0, y: 5 }
+      )
+      .addPanel(kubernetesAPIRequestsDuration, gridPos={ h: 8, w: 12, x: 0, y: 6 })
+      .addPanel(kubernetesAPIRequests, gridPos={ h: 8, w: 12, x: 12, y: 6 })
+      .addPanel(cpuUsage, gridPos={ h: 11, w: 12, x: 0, y: 14 })
+      .addPanel(memoryUsage, gridPos={ h: 11, w: 12, x: 12, y: 14 })
+      .addPanel(
+        row.new(
+          title='Reconciliation Stats'
+        ),
+        gridPos={ h: 1, w: 24, x: 0, y: 25 }
+      )
+      .addPanel(clusterReconciliationDuration, gridPos={ h: 8, w: 24, x: 0, y: 26 })
+      .addPanel(clusterReconciliationOpsMin, gridPos={ h: 9, w: 12, x: 0, y: 34 })
+      .addPanel(gitSourcesOpsMin, gridPos={ h: 9, w: 12, x: 12, y: 34 })
+      .addPanel(
+        row.new(
+          title='Helm Stats'
+        ),
+        gridPos={ h: 1, w: 24, x: 0, y: 43 }
+      )
+      .addPanel(helmReleaseDuration, gridPos={ h: 8, w: 24, x: 0, y: 44 })
+      .addPanel(helmReleasesOpsMin, gridPos={ h: 9, w: 12, x: 0, y: 52 })
+      .addPanel(helmChartsOpsMin, gridPos={ h: 9, w: 12, x: 12, y: 52 }),
+  },
+}

--- a/files/alerts.yml
+++ b/files/alerts.yml
@@ -1,0 +1,13 @@
+"groups":
+- "name": "flux-alert"
+  "rules":
+  - "alert": "FluxReconcilationFailed"
+    "annotations":
+      "description": "{{ $labels.kind }} {{ $labels.name }} reconcilation has been failed for more than 10 minutes in {{ $labels.exported_namespace }} namespace"
+      "runbook_url": ""
+      "summary": "Flux {{ $labels.kind }} {{ $labels.name }} failed"
+    "expr": |
+      max(gotk_reconcile_condition{status="False",type="Ready"}) by (namespace, name, kind) + on(namespace, name, kind) (max(gotk_reconcile_condition{status="Deleted"}) by (namespace, name, kind)) * 2 == 1
+    "for": "10m"
+    "labels":
+      "severity": "warning"

--- a/files/dashboards/flux-cluster.json
+++ b/files/dashboards/flux-cluster.json
@@ -1,0 +1,889 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 100
+                     }
+                  ]
+               },
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "links": [ ],
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "last"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto"
+         },
+         "pluginVersion": "7",
+         "targets": [
+            {
+               "expr": "count(gotk_reconcile_condition{cluster=\"$cluster\",namespace=~\"$namespace\",type=\"Ready\",status=\"True\",kind=~\"Kustomization|HelmRelease\"})\n-\nsum(gotk_reconcile_condition{cluster=\"$cluster\",namespace=~\"$namespace\",type=\"Ready\",status=\"Deleted\",kind=~\"Kustomization|HelmRelease\"})\n",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "title": "Cluster Reconcilers",
+         "transparent": false,
+         "type": "stat"
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "red",
+                        "value": null
+                     }
+                  ]
+               },
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 0
+         },
+         "id": 3,
+         "links": [ ],
+         "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "last"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto"
+         },
+         "pluginVersion": "7",
+         "targets": [
+            {
+               "expr": "sum(gotk_reconcile_condition{cluster=\"$cluster\",namespace=~\"$namespace\",type=\"Ready\",status=\"False\",kind=~\"Kustomization|HelmRelease\"})",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "title": "Failing Reconcilers",
+         "transparent": false,
+         "type": "stat"
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 100
+                     }
+                  ]
+               },
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 0
+         },
+         "id": 4,
+         "links": [ ],
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "last"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto"
+         },
+         "pluginVersion": "7",
+         "targets": [
+            {
+               "expr": "count(gotk_reconcile_condition{cluster=\"$cluster\",namespace=~\"$namespace\",type=\"Ready\",status=\"True\",kind=~\"GitRepository|HelmRepository|Bucket\"})\n-\nsum(gotk_reconcile_condition{cluster=\"$cluster\",namespace=~\"$namespace\",type=\"Ready\",status=\"Deleted\",kind=~\"GitRepository|HelmRepository|Bucket\"})\n",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "title": "Kubernetes Manifests Sources",
+         "transparent": false,
+         "type": "stat"
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "red",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 0
+         },
+         "id": 5,
+         "links": [ ],
+         "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "last"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto"
+         },
+         "pluginVersion": "7",
+         "targets": [
+            {
+               "expr": "sum(gotk_reconcile_condition{cluster=\"$cluster\",namespace=~\"$namespace\",type=\"Ready\",status=\"False\",kind=~\"GitRepository|HelmRepository|Bucket\"})",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "title": "Failing Sources",
+         "transparent": false,
+         "type": "stat"
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 1
+                     },
+                     {
+                        "color": "red",
+                        "value": 61
+                     }
+                  ]
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 4,
+            "w": 12,
+            "x": 0,
+            "y": 5
+         },
+         "id": 6,
+         "options": {
+            "orientation": "horizontal",
+            "reduceOptions": {
+               "calcs": [
+                  "mean"
+               ],
+               "fields": "",
+               "values": false
+            }
+         },
+         "targets": [
+            {
+               "expr": "sum(rate(gotk_reconcile_duration_seconds_sum{cluster=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\nsum(rate(gotk_reconcile_duration_seconds_count{cluster=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{kind}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Reconciler ops avg. duration",
+         "type": "bargauge"
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 1
+                     },
+                     {
+                        "color": "red",
+                        "value": 61
+                     }
+                  ]
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 4,
+            "w": 12,
+            "x": 12,
+            "y": 5
+         },
+         "id": 7,
+         "options": {
+            "orientation": "horizontal",
+            "reduceOptions": {
+               "calcs": [
+                  "mean"
+               ],
+               "fields": "",
+               "values": false
+            }
+         },
+         "targets": [
+            {
+               "expr": "sum(rate(gotk_reconcile_duration_seconds_sum{cluster=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket\"}[5m])) by (kind)\n/\nsum(rate(gotk_reconcile_duration_seconds_count{cluster=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket\"}[5m])) by (kind)\n",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{kind}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Source ops avg. duration",
+         "type": "bargauge"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+         },
+         "id": 8,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Status",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "columns": [ ],
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "mappings": [
+                  {
+                     "from": "",
+                     "id": 1,
+                     "text": "Ready",
+                     "to": "",
+                     "type": 1,
+                     "value": "0"
+                  },
+                  {
+                     "from": "",
+                     "id": 2,
+                     "text": "Not Ready",
+                     "to": "",
+                     "type": 1,
+                     "value": "1"
+                  }
+               ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue",
+                        "value": null
+                     },
+                     {
+                        "color": "blue",
+                        "value": 0
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Status"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.displayMode",
+                        "value": "color-background"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+         },
+         "id": 9,
+         "links": [ ],
+         "styles": null,
+         "targets": [
+            {
+               "expr": "gotk_reconcile_condition{cluster=\"$cluster\",namespace=~\"$namespace\",type=\"Ready\",status=\"False\",kind=~\"Kustomization|HelmRelease\"}",
+               "format": "table",
+               "instant": true,
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Cluster reconciliation readiness",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "__name__": true,
+                     "app": true,
+                     "cluster": true,
+                     "container": true,
+                     "endpoint": true,
+                     "environment": true,
+                     "exported_namespace": true,
+                     "instance": true,
+                     "job": true,
+                     "kubernetes_namespace": true,
+                     "kubernetes_pod_name": true,
+                     "pod": true,
+                     "pod_template_hash": true,
+                     "project": true,
+                     "prometheus": true,
+                     "prometheus_replica": true,
+                     "receive": true,
+                     "status": true,
+                     "tenant_id": true,
+                     "type": true
+                  },
+                  "indexByName": { },
+                  "renameByName": {
+                     "Value": "Status",
+                     "kind": "Kind",
+                     "name": "Name",
+                     "namespace": "Namespace"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "columns": [ ],
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "mappings": [
+                  {
+                     "from": "",
+                     "id": 1,
+                     "text": "Ready",
+                     "to": "",
+                     "type": 1,
+                     "value": "0"
+                  },
+                  {
+                     "from": "",
+                     "id": 2,
+                     "text": "Not Ready",
+                     "to": "",
+                     "type": 1,
+                     "value": "1"
+                  }
+               ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue",
+                        "value": null
+                     },
+                     {
+                        "color": "blue",
+                        "value": 0
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Status"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.displayMode",
+                        "value": "color-background"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+         },
+         "id": 10,
+         "links": [ ],
+         "styles": null,
+         "targets": [
+            {
+               "expr": "gotk_reconcile_condition{cluster=\"$cluster\",namespace=~\"$namespace\",type=\"Ready\",status=\"False\",kind=~\"GitRepository|HelmRepository|Bucket\"}",
+               "format": "table",
+               "instant": true,
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Source acquisition readiness",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "__name__": true,
+                     "app": true,
+                     "cluster": true,
+                     "container": true,
+                     "endpoint": true,
+                     "environment": true,
+                     "exported_namespace": true,
+                     "instance": true,
+                     "job": true,
+                     "kubernetes_namespace": true,
+                     "kubernetes_pod_name": true,
+                     "pod": true,
+                     "pod_template_hash": true,
+                     "project": true,
+                     "prometheus": true,
+                     "prometheus_replica": true,
+                     "receive": true,
+                     "status": true,
+                     "tenant_id": true,
+                     "type": true
+                  },
+                  "indexByName": { },
+                  "renameByName": {
+                     "Value": "Status",
+                     "kind": "Kind",
+                     "name": "Name",
+                     "namespace": "Namespace"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+         },
+         "id": 11,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Timing",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 19
+         },
+         "id": 12,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(rate(gotk_reconcile_duration_seconds_sum{cluster=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n/\nsum(rate(gotk_reconcile_duration_seconds_count{cluster=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{kind}}/{{name}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Cluster reconciliation duration",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 27
+         },
+         "id": 13,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(rate(gotk_reconcile_duration_seconds_sum{cluster=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket\"}[5m])) by (kind, name)\n/\nsum(rate(gotk_reconcile_duration_seconds_count{cluster=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket\"}[5m])) by (kind, name)\n",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{kind}}/{{name}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Source acquisition duration",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      }
+   ],
+   "refresh": "",
+   "rows": [ ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "flux"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "prometheus",
+               "value": "prometheus"
+            },
+            "hide": 0,
+            "label": null,
+            "name": "datasource",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 2,
+            "includeAll": false,
+            "label": "cluster",
+            "multi": false,
+            "name": "cluster",
+            "options": [ ],
+            "query": "label_values(gotk_reconcile_condition, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [ ],
+            "query": "label_values(gotk_reconcile_condition{cluster=\"$cluster\"}, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-15m",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Flux / Cluster Stats",
+   "uid": "flux-cluster",
+   "version": 0
+}

--- a/files/dashboards/flux-control-plane.json
+++ b/files/dashboards/flux-control-plane.json
@@ -1,0 +1,1338 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 100
+                     }
+                  ]
+               },
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "links": [ ],
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "last"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto"
+         },
+         "pluginVersion": "7",
+         "targets": [
+            {
+               "expr": "sum(go_info{cluster=\"$cluster\",namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "title": "Controllers",
+         "transparent": false,
+         "type": "stat"
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue",
+                        "value": null
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 50
+                     },
+                     {
+                        "color": "red",
+                        "value": 100
+                     }
+                  ]
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 0
+         },
+         "id": 3,
+         "links": [ ],
+         "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto"
+         },
+         "pluginVersion": "7",
+         "targets": [
+            {
+               "expr": "max(workqueue_longest_running_processor_seconds{cluster=\"$cluster\",namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "seconds",
+               "refId": "A"
+            }
+         ],
+         "title": "Max Work Queue",
+         "transparent": false,
+         "type": "stat"
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue",
+                        "value": null
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 500000000
+                     },
+                     {
+                        "color": "red",
+                        "value": 900000000
+                     }
+                  ]
+               },
+               "unit": "decbits"
+            }
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 0
+         },
+         "id": 4,
+         "links": [ ],
+         "options": {
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+         },
+         "pluginVersion": "7",
+         "targets": [
+            {
+               "expr": "sum(go_memstats_alloc_bytes{cluster=\"$cluster\",namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "title": "Memory",
+         "transparent": false,
+         "type": "gauge"
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "blue",
+                        "value": null
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 50
+                     },
+                     {
+                        "color": "red",
+                        "value": 100
+                     }
+                  ]
+               },
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 0
+         },
+         "id": 5,
+         "links": [ ],
+         "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "mean"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "textMode": "auto"
+         },
+         "pluginVersion": "7",
+         "targets": [
+            {
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",namespace=\"$namespace\",pod=~\".*-controller-.*\"}[1m]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "requests",
+               "refId": "A"
+            }
+         ],
+         "title": "API Requests",
+         "transparent": false,
+         "type": "stat"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+         },
+         "id": 6,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Resource Usage",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 6
+         },
+         "id": 7,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.50, sum(rate(rest_client_request_latency_seconds_bucket{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "P50",
+               "refId": "A"
+            },
+            {
+               "expr": "histogram_quantile(0.90, sum(rate(rest_client_request_latency_seconds_bucket{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "P90",
+               "refId": "B"
+            },
+            {
+               "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_latency_seconds_bucket{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "P99",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Kubernetes API Requests Duration",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 6
+         },
+         "id": 8,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",namespace=\"$namespace\"}[1m]))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "total",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",namespace=\"$namespace\",code!~\"2..\"}[1m]))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "error",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Kubernetes API Requests",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 0,
+            "y": 14
+         },
+         "id": 9,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\",namespace=\"$namespace\",pod=~\".*-controller-.*\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "{{pod}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "CPU Usage",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 12,
+            "y": 14
+         },
+         "id": 10,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(go_memstats_alloc_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\",pod=~\".*-controller-.*\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "{{pod}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Memory Usage",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 25
+         },
+         "id": 11,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Reconciliation Stats",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 26
+         },
+         "id": 12,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "workqueue_longest_running_processor_seconds{cluster=\"$cluster\",name=\"kustomization\"}",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "kustomization",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Cluster Reconciliation Duration",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": true,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "decimals": 2,
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 34
+         },
+         "id": 13,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": false,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(increase(controller_runtime_reconcile_total{cluster=\"$cluster\",controller=\"kustomization\",result!=\"error\"}[1m])) by (controller)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "successful reconciliations",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(increase(controller_runtime_reconcile_total{cluster=\"$cluster\",controller=\"kustomization\",result=\"error\"}[1m])) by (controller)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "failed reconciliations",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Cluster Reconciliations ops/min",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 2,
+               "format": "opm",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 2,
+               "format": "opm",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": true,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "decimals": 2,
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 34
+         },
+         "id": 14,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": false,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(increase(controller_runtime_reconcile_total{cluster=\"$cluster\",controller=\"gitrepository\",result!=\"error\"}[1m]))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "successful git pulls",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(increase(controller_runtime_reconcile_total{cluster=\"$cluster\",controller=\"gitrepository\",result=\"error\"}[1m]))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "failed git pulls",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Git Sources ops/min",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 2,
+               "format": "opm",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 2,
+               "format": "opm",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 43
+         },
+         "id": 15,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Helm Stats",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 44
+         },
+         "id": 16,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{cluster=\"$cluster\",controller=\"helmrelease\"}[5m])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "P50",
+               "refId": "A"
+            },
+            {
+               "expr": "histogram_quantile(0.90, sum(rate(controller_runtime_reconcile_time_seconds_bucket{cluster=\"$cluster\",controller=\"helmrelease\"}[5m])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "P90",
+               "refId": "B"
+            },
+            {
+               "expr": "histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{cluster=\"$cluster\",controller=\"helmrelease\"}[5m])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "P99",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Helm",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": true,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "decimals": 2,
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 52
+         },
+         "id": 17,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": false,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(increase(controller_runtime_reconcile_total{cluster=\"$cluster\",controller=\"helmrelease\",result!=\"error\"}[1m])) by (controller)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "successful reconciliations",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(increase(controller_runtime_reconcile_total{cluster=\"$cluster\",controller=\"helmrelease\",result=\"error\"}[1m])) by (controller)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "failed reconciliations ",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Helm Releases ops/min",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 2,
+               "format": "opm",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 2,
+               "format": "opm",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": true,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "decimals": 2,
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 52
+         },
+         "id": 18,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": false,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(increase(controller_runtime_reconcile_total{cluster=\"$cluster\",controller=\"helmchart\",result!=\"error\"}[1m])) by (controller)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "successful chart pulls",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(increase(controller_runtime_reconcile_total{cluster=\"$cluster\",controller=\"helmchart\",result=\"error\"}[1m])) by (controller)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "failed chart pulls",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Helm Charts ops/min",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 2,
+               "format": "opm",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 2,
+               "format": "opm",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      }
+   ],
+   "refresh": "",
+   "rows": [ ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "flux"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "prometheus",
+               "value": "prometheus"
+            },
+            "hide": 0,
+            "label": null,
+            "name": "datasource",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 2,
+            "includeAll": false,
+            "label": "cluster",
+            "multi": false,
+            "name": "cluster",
+            "options": [ ],
+            "query": "label_values(gotk_reconcile_condition, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [ ],
+            "query": "label_values(gotk_reconcile_condition{cluster=\"$cluster\"}, namespace)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-15m",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Flux / Control Plane",
+   "uid": "flux-control-plane-test",
+   "version": 0
+}

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": ""
+        }
+      },
+      "version": "3626fc4dc2326931c530861ac5bebe39444f6cbf",
+      "sum": "Wqp0cxwrZu4CnTZlFOBPJzOCJdaJICYO5dkVi8rQ8Dk="
+    }
+  ],
+  "legacyImports": false
+}

--- a/mixin.libsonnet
+++ b/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'alerts/alerts.libsonnet') +
+(import 'dashboards/dashboards.libsonnet') +
+(import 'config.libsonnet')

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation {
+  name = "flux-mixin";
+
+  # The packages in the `buildInputs` list will be added to the PATH in our shell
+  buildInputs = with pkgs; [
+    jsonnet-bundler
+    go-jsonnet
+  ];
+}


### PR DESCRIPTION
Initialize Flux Mixin including
- Flux control plane, flux cluster with opt-in `showMultiCluster`
- Minimal alert from example in flux v2
- Makefile to generate example alerts, dashboards in the repo
- Nixpkgs (for nix peoples)
- Update README.md including requirements, use as dependency instruction, how to use

FYI: Implementation for grafonnet is 1-1 with flux v2 dashboards in the main repository but might be a bit old and need some adjustment