### PR TITLE
fix: remove delete status from alert

### DIFF
--- a/alerts/flux-alert.libsonnet
+++ b/alerts/flux-alert.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'FluxReconcilationFailed',
             expr: |||
-              max(gotk_reconcile_condition{status="False",type="Ready"}) by (namespace, name, kind) + on(namespace, name, kind) (max(gotk_reconcile_condition{status="Deleted"}) by (namespace, name, kind)) * 2 == 1
+              max(gotk_reconcile_condition{status="False",type="Ready"}) by (namespace, name, kind) == 1
             |||,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
Hello!

It seems like FluxReconcilationFailed isn't trigger with the last fluxcd changes. This is due to the following: https://github.com/fluxcd/pkg/pull/612
As you see the status="Deleted" has been removed. Therefore the following promql expression returns nothing:
`(max(gotk_reconcile_condition{status="Deleted"}`
and it affects the allert itself.

This change tested on our platform, works as expected. @stefanprodan could you please review it?